### PR TITLE
yongjun / week03 / 문제5 - 신입사원

### DIFF
--- a/Greedy/BOJ1946-신입사원/yongjun/Main.java
+++ b/Greedy/BOJ1946-신입사원/yongjun/Main.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	public static void main(String[] args) throws Exception {
+		// BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedReader br = new BufferedReader(new FileReader("res/input.txt"));
+
+		int T = Integer.parseInt(br.readLine());
+		
+		for (int tc = 0; tc < T; tc++) {
+			int n = Integer.parseInt(br.readLine());
+			
+			int[] arr = new int[n+1];
+						
+			for (int i = 0; i < n; i++) {
+				StringTokenizer st = new StringTokenizer(br.readLine());
+				int g1 = Integer.parseInt(st.nextToken());
+				int g2 = Integer.parseInt(st.nextToken());
+				
+				arr[g1] = g2; // 서류 성적 순 정렬
+			}
+			
+			int top = arr[1]; // 서류 1등은 무조건 선발된다.
+			int sum = 1;
+			
+			for (int i = 2; i < n+1; i++) {
+				// 서류 성적 순으로 면접 성적을 확인
+				// 선발된 사람의 면접 성적보다 높은 성적이 나오면 선발
+				if(arr[i] < top) {
+					sum++;
+					top = arr[i];
+				}
+			}
+			
+			System.out.println(sum);
+		}
+		
+		
+		br.close();
+	}
+}


### PR DESCRIPTION
### ✏ 풀이 요약
1. 서류 성적 순으로 정렬
2. 서류 1등을 선발인원 수에 추가
3. 서류 1등의 면접 등수를 변수에 저장(배열은 서류 성적순으로 정렬 되어있으며, 변수의 면접 등수보다 낮으면 선발될 수 없다.)
4. 배열을 탐색하며 면접 성적을 확인.
5. 선발된 사람의 면접 성적보다 높은 성적이 나오면 선발

### ✏ 후기
정렬 해야겠다는 생각은 들었지만 처음 생각한 구현에서는 시간 초과가 나왔다.
서류순으로 정렬하고 자기보다 위에 위치한 사람 중에  면접 점수가 더 높은 사람이 있으면 탈락시키는 방식이였는데 지원자 숫자가 최대 100,000명이라 이 방식은 시간 초과 날 수밖에 없었다.
그래서 선형으로 해결하기 위해 선발한 사람의 면접 점수를 저장하는 변수를 만들었다.