### PR TITLE
hyeyeon / week05 / 문제2 - 최단경로, 문제3 - 특정 거리의 도시 찾기

### DIFF
--- a/Dijkstra/BOJ1753-최단경로/hyeyeon/BOJ1753_최단경로.java
+++ b/Dijkstra/BOJ1753-최단경로/hyeyeon/BOJ1753_최단경로.java
@@ -1,0 +1,85 @@
+package A0311;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+class Edge implements Comparable<Edge>{
+	int node;
+	int cost;
+	Edge(int node, int cost){
+		this.node = node;
+		this.cost = cost;
+	}
+	@Override
+    public int compareTo(Edge node) { //우선순위: 비용이 적은 순
+        return this.cost <= node.cost ? -1 : 1;
+    }
+}
+public class BOJ1753_최단경로 {
+	static int V, E, K;
+	static ArrayList<ArrayList<Edge>> arr;
+	static int[] dist;
+	static void solve(int n) {
+		PriorityQueue<Edge> pq = new PriorityQueue<>();
+		dist[n]=0;
+		pq.add(new Edge(n,dist[n])); //우선순위 큐에 정점과 시작점부터 그 정점까지의 최단 거리를 담는다
+		
+		while(!pq.isEmpty()) {
+			Edge tmp = pq.poll();
+			int tmpNode = tmp.node;
+			int tmpCost = tmp.cost;
+			
+			if(tmpCost>dist[tmpNode]) continue;
+			
+			for(Edge e : arr.get(tmpNode)) {
+				int nxtNode = e.node;
+				int nxtCost = e.cost;
+				if(tmpCost+nxtCost<dist[nxtNode]) {
+					dist[nxtNode]=tmpCost+nxtCost;
+					pq.add(new Edge(nxtNode,dist[nxtNode]));
+				}
+			}
+		}
+		
+	}
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		st = new StringTokenizer(br.readLine());
+		V = Integer.parseInt(st.nextToken());
+		E = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(br.readLine());
+		arr = new ArrayList<ArrayList<Edge>>();
+		dist = new int[V+1];
+		//인접리스트, 최단거리 배열 초기화
+		for(int i=0;i<=V;i++) {
+			arr.add(new ArrayList<>());
+			dist[i]=Integer.MAX_VALUE;
+		}
+		//인접리스트 입력
+		for(int i=1;i<=E;i++) {
+			st = new StringTokenizer(br.readLine());
+			int u = Integer.parseInt(st.nextToken());
+			int v = Integer.parseInt(st.nextToken());
+			int w = Integer.parseInt(st.nextToken());
+			arr.get(u).add(new Edge(v,w));
+		}
+		
+		solve(K);
+		
+		for(int i=1;i<=V;i++) {
+			if(dist[i]==Integer.MAX_VALUE) {
+				System.out.println("INF");
+			}
+			else
+				System.out.println(dist[i]);
+			
+		}
+		
+	}
+
+}

--- a/Dijkstra/BOJ18352-특정거리의도시찾기/hyeyeon/BOJ18352_특정거리의도시찾기.java
+++ b/Dijkstra/BOJ18352-특정거리의도시찾기/hyeyeon/BOJ18352_특정거리의도시찾기.java
@@ -1,0 +1,82 @@
+package A0311;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+class info implements Comparable<info>{
+	int node;
+	int dist;
+	
+	info(int node, int dist){
+		this.node = node;
+		this.dist = dist;
+	}
+	@Override
+    public int compareTo(info node) { //우선순위: 비용이 적은 순
+        return this.dist <= node.dist ? -1 : 1;
+    }
+}
+public class BOJ18352_특정거리의도시찾기 {
+	
+	static int N, M, K, X;
+	static ArrayList<ArrayList<Integer>> map;
+	static int[] dist;
+	static void solve(int n) {
+		PriorityQueue<info> q = new PriorityQueue<>();
+		dist[n]=0;
+		for(int i=0;i<map.get(n).size();i++) {
+			q.add(new info(map.get(n).get(i),dist[n]));
+		}
+		
+		while(!q.isEmpty()) {
+			info tmp = q.poll();
+			int nxt = tmp.node;
+			int tmpdist = tmp.dist;
+			if(dist[nxt]>tmpdist+1) {
+				dist[nxt] = tmpdist+1;
+				for(int i=0;i<map.get(nxt).size();i++) {
+					q.add(new info(map.get(nxt).get(i),dist[nxt]));
+				}
+			}
+		}
+	}
+	
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		X = Integer.parseInt(st.nextToken());
+		map = new ArrayList<ArrayList<Integer>>();
+		dist = new int[N+1];
+		for(int i=0;i<=N;i++) {
+			map.add(new ArrayList<>());
+			dist[i]=Integer.MAX_VALUE;
+		}
+		for(int i=0;i<M;i++) {
+			st = new StringTokenizer(br.readLine());
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken()); 
+			map.get(from).add(to);
+		}
+		solve(X);
+		boolean flag = false;
+		for(int i=1;i<dist.length;i++) {
+			if(dist[i]==K) {
+				System.out.println(i);
+				flag=true;
+			}
+			
+		}
+		if(!flag) System.out.println(-1);
+	}
+	
+
+}

--- a/Dijkstra/BOJ18352-특정거리의도시찾기/hyeyeon/BOJ18352_특정거리의도시찾기_queue.java
+++ b/Dijkstra/BOJ18352-특정거리의도시찾기/hyeyeon/BOJ18352_특정거리의도시찾기_queue.java
@@ -1,0 +1,83 @@
+package A0308;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+class info implements Comparable<info>{
+	int node;
+	int dist;
+	
+	info(int node, int dist){
+		this.node = node;
+		this.dist = dist;
+	}
+	@Override
+    public int compareTo(info node) { //우선순위: 비용이 적은 순
+        return this.dist <= node.dist ? -1 : 1;
+    }
+}
+public class BOJ18352_특정거리의도시찾기_queue {
+	
+	static int N, M, K, X;
+	static ArrayList<ArrayList<Integer>> map;
+	static int[] dist;
+	static void solve(int n) {
+		//PriorityQueue<info> q = new PriorityQueue<>();
+		Queue<info> q = new LinkedList<>();
+		dist[n]=0;
+		for(int i=0;i<map.get(n).size();i++) {
+			q.add(new info(map.get(n).get(i),dist[n]));
+		}
+		
+		while(!q.isEmpty()) {
+			info tmp = q.poll();
+			int nxt = tmp.node;
+			int tmpdist = tmp.dist;
+			if(dist[nxt]>tmpdist+1) {
+				dist[nxt] = tmpdist+1;
+				for(int i=0;i<map.get(nxt).size();i++) {
+					q.add(new info(map.get(nxt).get(i),dist[nxt]));
+				}
+			}
+		}
+	}
+	
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		X = Integer.parseInt(st.nextToken());
+		map = new ArrayList<ArrayList<Integer>>();
+		dist = new int[N+1];
+		for(int i=0;i<=N;i++) {
+			map.add(new ArrayList<>());
+			dist[i]=Integer.MAX_VALUE;
+		}
+		for(int i=0;i<M;i++) {
+			st = new StringTokenizer(br.readLine());
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken()); 
+			map.get(from).add(to);
+		}
+		solve(X);
+		boolean flag = false;
+		for(int i=1;i<dist.length;i++) {
+			if(dist[i]==K) {
+				System.out.println(i);
+				flag=true;
+			}
+			
+		}
+		if(!flag) System.out.println(-1);
+	}
+	
+}


### PR DESCRIPTION
### ✏ 풀이 요약
 - 문제 2 : 다익스트라를 이용하여 풀이하였다. 우선순위 큐에 정점과 시작점부터 그 정점까지의 최단 거리를 담는다. 모든 정점을 탐색해야 하므로 큐가 빌 때까지 조사하여야 한다. 
 - 문제 3 : 다익스트라를 이용하여 풀이하였다. 큐에 노드와 거리를 넣고 큐가 빌 때까지 갱신되는 거리와 기존 거리를 비교한다. 거리는 dist 배열에 저장한다.
 
### ✏ 후기
 - 문제 2 : 우선 순위 큐를 처음 제대로 사용해보았다. 아직 익숙하지 않아 어려웠지만 많이 중요한 것 같아서 앞으로 관련 문제를 풀어봐야겠다.
 - 문제 3 : 모든 도로의 거리가 1이기 때문에 우선순위 큐를 사용하지 않아도 될 것이라 생각하였다. 우선순위 큐와 큐 둘 다 이용하여 풀어보았더니 두 방법 모두 정답이었다. 